### PR TITLE
Release the binary

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -51,7 +51,7 @@ jobs:
       TARGET_FLAGS:
       TARGET_DIR: ./target
       RUST_BACKTRACE: 1
-      BIN_NAME: bast
+      BIN_NAME: kantig
     strategy:
       matrix:
         build: [linux-musl, linux-gnu, macos, win-msvc, win-gnu, win32-msvc]

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,176 @@
+name: Release Binary
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  create-release:
+    name: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create artifacts directory
+        run: mkdir artifacts
+
+      - name: Get the release version from the tag
+        if: env.ARTIFACT_VERSION == ''
+        run: |
+          # Apparently, this is the right way to get a tag name. Really?
+          #
+          # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
+          echo "::set-env name=ARTIFACT_VERSION::${GITHUB_REF#refs/tags/}"
+          echo "version is: ${{ env.ARTIFACT_VERSION }}"
+      - name: Create GitHub release
+        id: release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.ARTIFACT_VERSION }}
+          release_name: ${{ env.ARTIFACT_VERSION }}
+
+      - name: Save release upload URL to artifact
+        run: echo "${{ steps.release.outputs.upload_url }}" > artifacts/release-upload-url
+
+      - name: Save version number to artifact
+        run: echo "${{ env.ARTIFACT_VERSION }}" > artifacts/release-version
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: artifacts
+          path: artifacts
+
+  build-release:
+    name: build-release
+    needs: ["create-release"]
+    runs-on: ${{ matrix.os }}
+    env:
+      CARGO: cargo
+      TARGET_FLAGS:
+      TARGET_DIR: ./target
+      RUST_BACKTRACE: 1
+      BIN_NAME: bast
+    strategy:
+      matrix:
+        build: [linux-musl, linux-gnu, macos, win-msvc, win-gnu, win32-msvc]
+        include:
+          - build: linux-musl
+            os: ubuntu-18.04
+            rust: stable
+            target: x86_64-unknown-linux-musl
+            compiler: cross
+          - build: linux-gnu
+            os: ubuntu-18.04
+            rust: stable
+            target: x86_64-unknown-linux-gnu
+            compiler: cargo
+          - build: macos
+            os: macos-latest
+            rust: stable
+            target: x86_64-apple-darwin
+            compiler: cross
+          - build: win-msvc
+            os: windows-2019
+            rust: nightly
+            target: x86_64-pc-windows-msvc
+            compiler: cross
+          - build: win-gnu
+            os: windows-2019
+            rust: nightly-x86_64-gnu
+            target: x86_64-pc-windows-gnu
+            compiler: cross
+          - build: win32-msvc
+            os: windows-2019
+            rust: nightly
+            target: i686-pc-windows-msvc
+            compiler: cross
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Install packages linux gnu
+        if: matrix.build == 'linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential pkg-config 
+          
+      - name: Install packages linux musl
+        if: matrix.build == 'linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool pkg-config musl-tools 
+      - name: Install packages linux macos
+        if: matrix.os == 'macos-latest'
+        run: |
+          echo "Only for future"
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+
+      - name: Setup Env Var
+        run: |
+          # cargo install --git https://github.com/rust-embedded/cross
+          echo "::set-env name=CARGO:: ${{ matrix.compiler }}"
+          echo "::set-env name=TARGET_FLAGS::--target ${{ matrix.target }}"
+          echo "::set-env name=TARGET_DIR::./target/${{ matrix.target }}"
+      - name: Show command used for Cargo
+        run: |
+          echo "cargo command is: ${{ env.CARGO }}"
+          echo "target flag is: ${{ env.TARGET_FLAGS }}"
+          echo "target dir is: ${{ env.TARGET_DIR }}"
+      - name: Get release download URL
+        uses: actions/download-artifact@v1
+        with:
+          name: artifacts
+          path: artifacts
+
+      - name: Set release upload URL and release version
+        shell: bash
+        run: |
+          release_upload_url="$(cat artifacts/release-upload-url)"
+          echo "::set-env name=RELEASE_UPLOAD_URL::$release_upload_url"
+          echo "release upload url: $RELEASE_UPLOAD_URL"
+          release_version="$(cat artifacts/release-version)"
+          echo "::set-env name=RELEASE_VERSION::$release_version"
+          echo "release version: $RELEASE_VERSION"
+
+      - name: Build release binary
+        run: ${{ env.CARGO }} build --verbose --release ${{ env.TARGET_FLAGS }}
+
+      - name: Strip release binary (linux and macos)
+        if: matrix.build == 'linux-musl' || matrix.build == 'linux-gnu' || matrix.build == 'macos'
+        run: strip "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}"
+
+      - name: Build archive
+        shell: bash
+        run: |
+          staging="${{ env.BIN_NAME }}-${{ env.RELEASE_VERSION }}-${{ matrix.target }}"
+          mkdir -p "$staging"
+          cp {README.md,rainbow_color_mapper.py} "$staging/"
+          if [ "${{ matrix.os }}" = "windows-2019" ]; then
+            cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}.exe" "$staging/"
+            7z a "$staging.zip" "$staging"
+            echo "::set-env name=ASSET::$staging.zip"
+          else
+            cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}" "$staging/"
+            tar czf "$staging.tar.gz" "$staging"
+            echo "::set-env name=ASSET::$staging.tar.gz"
+          fi
+      - name: Upload release archive
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
+          asset_path: ${{ env.ASSET }}
+          asset_name: ${{ env.ASSET }}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Setup Env Var
         run: |
-          # cargo install --git https://github.com/rust-embedded/cross
+          cargo install --git https://github.com/rust-embedded/cross
           echo "::set-env name=CARGO:: ${{ matrix.compiler }}"
           echo "::set-env name=TARGET_FLAGS::--target ${{ matrix.target }}"
           echo "::set-env name=TARGET_DIR::./target/${{ matrix.target }}"


### PR DESCRIPTION
This PR is released to make use of Kantig easier and ergonomic. Now user can download directly from github release tab.

Musl is also used to make linking static.


Demo can be seen here: https://github.com/shirshak55/kantig/releases/tag/v0.0.3

Thanks.

🎉🎉🎉🎉🎉